### PR TITLE
Update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,18 @@
 module.exports = {
+  'extends': [
+    'eslint:recommended',
+    'plugin:react/recommended'
+  ],
   'plugins': [
     'react'
   ],
   'globals': {
-    '__DEV__': true
+    '__DEV__': true,
+    '__webpack_public_path__': true
   },
   'env': {
-    'shared-node-browser': true,
+    'browser': true,
+    'node': true,
     'es6': true,
   },
   'parserOptions': {
@@ -163,49 +169,16 @@ module.exports = {
 /**
  * JSX style
  */
+    'jsx-quotes': [2, 'prefer-single'],
     'react/display-name': 0,
     'react/jsx-boolean-value': 2,
-    'jsx-quotes': [2,'prefer-single'],
-    'react/jsx-no-undef': 2,
-    'react/jsx-sort-props': 0,
-    'react/jsx-sort-prop-types': 0,
-    'react/jsx-uses-react': 2,
-    'react/jsx-uses-vars': 2,
-    'react/jsx-no-duplicate-props': 2, // explodes with strict mode in IE
-    'react/no-did-mount-set-state': [2, 'allow-in-func'],
-    'react/no-did-update-set-state': 2,
     'react/no-multi-comp': [2, {     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md#ignorestateless
         'ignoreStateless': true
     }],
-    'react/no-unknown-property': 2,
-    'react/prop-types': 2,
-    'react/react-in-jsx-scope': 2,
     'react/self-closing-comp': 2,
     'react/wrap-multilines': 2,
     'react/sort-comp': [2, {
-      'order': [
-        'displayName',
-        'mixins',
-        'statics',
-        'contextTypes',
-        'propTypes',
-        'constructor',
-        'getDefaultProps',
-        'defaultProps',
-        'getInitialState',
-        'state',
-        'componentWillMount',
-        'componentDidMount',
-        'componentWillReceiveProps',
-        'shouldComponentUpdate',
-        'componentWillUpdate',
-        'componentDidUpdate',
-        'componentWillUnmount',
-        '/^(on|handle).+$/',
-        '/^get.+$/',
-        '/^render.+$/',
-        'render'
-      ]
+      'order': ['lifecycle', 'everything-else', 'render']
     }]
   }
 };

--- a/index.js
+++ b/index.js
@@ -160,6 +160,7 @@ module.exports = {
       'before': false,
       'after': true
     }],
+    'object-curly-spacing': [2, 'never'],
     'keyword-spacing': 2,       // http://eslint.org/docs/rules/keyword-spacing
     'space-before-blocks': 2,        // http://eslint.org/docs/rules/space-before-blocks
     'space-before-function-paren': [2, 'never'], // http://eslint.org/docs/rules/space-before-function-paren

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  'parser': 'babel-eslint',
   'plugins': [
     'react'
   ],
@@ -7,26 +6,17 @@ module.exports = {
     '__DEV__': true
   },
   'env': {
-    'browser': true,
-    'node': true
+    'shared-node-browser': true,
+    'es6': true,
   },
-  'ecmaFeatures': {
-    'arrowFunctions': true,
-    'blockBindings': true,
-    'classes': true,
-    'defaultParams': true,
-    'destructuring': true,
-    'forOf': true,
-    'generators': false,
-    'modules': true,
-    'objectLiteralComputedProperties': true,
-    'objectLiteralDuplicateProperties': false,
-    'objectLiteralShorthandMethods': true,
-    'objectLiteralShorthandProperties': true,
-    'spread': true,
-    'superInFunctions': true,
-    'templateStrings': true,
-    'jsx': true
+  'parserOptions': {
+    'ecmaVersion': 6,
+    'sourceType': 'module',
+    'ecmaFeatures': {
+      'experimentalObjectRestSpread': true,
+      'jsx': true
+    },
+    
   },
   'rules': {
 /**
@@ -129,7 +119,7 @@ module.exports = {
       'allowSingleLine': true
     }],
     'quotes': [
-      2, 'single', 'avoid-escape'    // http://eslint.org/docs/rules/quotes
+      2, 'single', {'avoidEscape': true, 'allowTemplateLiterals': true}    // http://eslint.org/docs/rules/quotes
     ],
     'camelcase': [2, {               // http://eslint.org/docs/rules/camelcase
       'properties': 'never'
@@ -164,11 +154,10 @@ module.exports = {
       'before': false,
       'after': true
     }],
-    'space-after-keywords': 2,       // http://eslint.org/docs/rules/space-after-keywords
+    'keyword-spacing': 2,       // http://eslint.org/docs/rules/keyword-spacing
     'space-before-blocks': 2,        // http://eslint.org/docs/rules/space-before-blocks
     'space-before-function-paren': [2, 'never'], // http://eslint.org/docs/rules/space-before-function-paren
     'space-infix-ops': 2,            // http://eslint.org/docs/rules/space-infix-ops
-    'space-return-throw-case': 2,    // http://eslint.org/docs/rules/space-return-throw-case
     'spaced-comment': [2, 'always'],        // http://eslint.org/docs/rules/spaced-comment
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-interactivethings",
-  "version": "2.0.6",
+  "version": "3.0.0-beta.1",
   "description": "The Interactive Things ESLint config",
   "repository": "https://github.com/interactivethings/eslint-config-interactivethings",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-interactivethings",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "description": "The Interactive Things ESLint config",
   "repository": "https://github.com/interactivethings/eslint-config-interactivethings",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-interactivethings",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "The Interactive Things ESLint config",
   "repository": "https://github.com/interactivethings/eslint-config-interactivethings",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -10,9 +10,8 @@
   "author": "Jeremy Stucki",
   "main": "index.js",
   "peerDependencies": {
-    "babel-eslint": ">=4.1.1 || ^5.0.0-beta6",
-    "eslint": "^1.3.1",
-    "eslint-plugin-react": "^3.1.1"
+    "eslint": "^2.11.0",
+    "eslint-plugin-react": "^5.1.1"
   },
   "license": "BSD-3-Clause"
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Jeremy Stucki",
   "main": "index.js",
   "peerDependencies": {
-    "eslint": "^2.11.0",
+    "eslint": "^2.11.0 || ^3.0.0",
     "eslint-plugin-react": "^5.1.1"
   },
   "license": "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-interactivethings",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "description": "The Interactive Things ESLint config",
   "repository": "https://github.com/interactivethings/eslint-config-interactivethings",
   "keywords": [


### PR DESCRIPTION
Works with the latest versions of eslint and eslint-plugin-react. Removes babel-eslint, as it's not needed anymore.

Breaking change because eslint-plugin-react has gotten pickier about some things 😄 
